### PR TITLE
Use http_host if server_name not set.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.bin
 /build
 /vendor
+*.swp

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -219,8 +219,10 @@ class Request
     {
         $scheme = $this->getServer('REQUEST_SCHEME');
         $https  = $this->getServer('HTTPS') == 'on' ? true : false;
-        $server = $this->getServer('SERVER_NAME');
         $port   = $this->getServer('SERVER_PORT');
+        $server = ! empty($this->getServer('SERVER_NAME'))
+            ? $this->getServer('SERVER_NAME')
+            : $this->getServer('HTTP_HOST');
 
         $port  = ($port == '80')
             ? ''
@@ -235,7 +237,7 @@ class Request
         $url  = $scheme ? $scheme : 'http';
         $url .= '://';
         $url .= $server . $port . htmlspecialchars($uri);
-        
+
         return $url;
     }
 

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -220,8 +220,8 @@ class Request
         $scheme = $this->getServer('REQUEST_SCHEME');
         $https  = $this->getServer('HTTPS') == 'on' ? true : false;
         $port   = $this->getServer('SERVER_PORT');
-        $server = ! empty($this->getServer('SERVER_NAME'))
-            ? $this->getServer('SERVER_NAME')
+        $server = ! empty($server_name = $this->getServer('SERVER_NAME'))
+            ? $server_name
             : $this->getServer('HTTP_HOST');
 
         $port  = ($port == '80')

--- a/test/Request/RequestTest.php
+++ b/test/Request/RequestTest.php
@@ -209,6 +209,125 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
 
+    /**
+     * Provider for $_SERVER
+     *
+     * @return array
+     */
+    public function providerGetCurrentUrlNoServerName()
+    {
+        return [
+            [
+                [
+                    'REQUEST_SCHEME' => "http",
+                    'HTTPS'       => null, //"on",
+                    'SERVER_NAME' => "",
+                    'HTTP_HOST'   => "dbwebb.se",
+                    'SERVER_PORT' => "80",
+                    'REQUEST_URI' => "/",
+                    'url'         => "http://dbwebb.se",
+                ]
+            ],
+            [
+                [
+                    'REQUEST_SCHEME' => "http",
+                    'HTTPS'       => null, //"on",
+                    'SERVER_NAME' => "",
+                    'HTTP_HOST'   => "dbwebb.se",
+                    'SERVER_PORT' => "80",
+                    'REQUEST_URI' => "/img",
+                    'url'         => "http://dbwebb.se/img",
+                ]
+            ],
+            [
+                [
+                    'REQUEST_SCHEME' => "http",
+                    'HTTPS'       => null, //"on",
+                    'SERVER_NAME' => "",
+                    'HTTP_HOST'   => "dbwebb.se",
+                    'SERVER_PORT' => "80",
+                    'REQUEST_URI' => "/img/",
+                    'url'         => "http://dbwebb.se/img",
+                ]
+            ],
+            [
+                [
+                    'REQUEST_SCHEME' => "http",
+                    'HTTPS'       => null, //"on",
+                    'SERVER_NAME' => "",
+                    'HTTP_HOST'   => "dbwebb.se",
+                    'SERVER_PORT' => "80",
+                    'REQUEST_URI' => "/anax-mvc/webroot/app.php",
+                    'url'         => "http://dbwebb.se/anax-mvc/webroot/app.php",
+                ]
+            ],
+            [
+                [
+                    'REQUEST_SCHEME' => "http",
+                    'HTTPS'       => null, //"on",
+                    'SERVER_NAME' => "",
+                    'HTTP_HOST'   => "dbwebb.se",
+                    'SERVER_PORT' => "8080",
+                    'REQUEST_URI' => "/anax-mvc/webroot/app.php",
+                    'url'         => "http://dbwebb.se:8080/anax-mvc/webroot/app.php",
+                ]
+            ],
+            [
+                [
+                    'REQUEST_SCHEME' => "https",
+                    'HTTPS'       => "on", //"on",
+                    'SERVER_NAME' => "",
+                    'HTTP_HOST'   => "dbwebb.se",
+                    'SERVER_PORT' => "443",
+                    'REQUEST_URI' => "/anax-mvc/webroot/app.php",
+                    'url'         => "https://dbwebb.se/anax-mvc/webroot/app.php",
+                ]
+            ],
+            [
+                [
+                    'REQUEST_SCHEME' => "https",
+                    'HTTPS'       => "on", //"on",
+                    'SERVER_NAME' => "",
+                    'HTTP_HOST'   => "dbwebb.se",
+                    'SERVER_PORT' => "8080",
+                    'REQUEST_URI' => "/anax-mvc/webroot/app.php",
+                    'url'         => "https://dbwebb.se:8080/anax-mvc/webroot/app.php",
+                ]
+            ],
+        ];
+    }
+
+
+
+    /**
+     * Test
+     *
+     * @param string $server the $_SERVER part
+     *
+     * @return void
+     *
+     * @dataProvider providerGetCurrentUrlNoServerName
+     *
+     */
+    public function testGetCurrentUrlNoServerName($server)
+    {
+        /* $this->request->setServer('REQUEST_SCHEME', $server['REQUEST_SCHEME']); */
+        /* $this->request->setServer('HTTPS', $server['HTTPS']); */
+        /* $this->request->setServer('SERVER_NAME', $server['SERVER_NAME']); */
+        /* $this->request->setServer('SERVER_PORT', $server['SERVER_PORT']); */
+        /* $this->request->setServer('REQUEST_URI', $server['REQUEST_URI']); */
+
+        $fakeGlobal = ['server' => $server];
+
+        $this->request->setGlobals($fakeGlobal);
+
+        $url = $fakeGlobal['server']['url'];
+
+        $res = $this->request->getCurrentUrl();
+
+        $this->assertEquals($url, $res, "Failed url: " . $url);
+    }
+
 
     /**
      * Provider for $_SERVER

--- a/test/Request/RequestTest.php
+++ b/test/Request/RequestTest.php
@@ -221,8 +221,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 [
                     'REQUEST_SCHEME' => "http",
                     'HTTPS'       => null, //"on",
-                    'SERVER_NAME' => "",
-                    'HTTP_HOST'   => "dbwebb.se",
+                    'SERVER_NAME' => "dbwebb.se",
+                    'HTTP_HOST'   => "webdev.dbwebb.se",
                     'SERVER_PORT' => "80",
                     'REQUEST_URI' => "/",
                     'url'         => "http://dbwebb.se",
@@ -233,17 +233,17 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                     'REQUEST_SCHEME' => "http",
                     'HTTPS'       => null, //"on",
                     'SERVER_NAME' => "",
-                    'HTTP_HOST'   => "dbwebb.se",
+                    'HTTP_HOST'   => "webdev.dbwebb.se",
                     'SERVER_PORT' => "80",
                     'REQUEST_URI' => "/img",
-                    'url'         => "http://dbwebb.se/img",
+                    'url'         => "http://webdev.dbwebb.se/img",
                 ]
             ],
             [
                 [
                     'REQUEST_SCHEME' => "http",
                     'HTTPS'       => null, //"on",
-                    'SERVER_NAME' => "",
+//                    'SERVER_NAME' => "",
                     'HTTP_HOST'   => "dbwebb.se",
                     'SERVER_PORT' => "80",
                     'REQUEST_URI' => "/img/",
@@ -311,12 +311,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetCurrentUrlNoServerName($server)
     {
-        /* $this->request->setServer('REQUEST_SCHEME', $server['REQUEST_SCHEME']); */
-        /* $this->request->setServer('HTTPS', $server['HTTPS']); */
-        /* $this->request->setServer('SERVER_NAME', $server['SERVER_NAME']); */
-        /* $this->request->setServer('SERVER_PORT', $server['SERVER_PORT']); */
-        /* $this->request->setServer('REQUEST_URI', $server['REQUEST_URI']); */
-
         $fakeGlobal = ['server' => $server];
 
         $this->request->setGlobals($fakeGlobal);


### PR DESCRIPTION
Just added a quick check on SERVER_NAME. If empty by PHP standards then use HTTP_HOST.

Added new test case.  